### PR TITLE
Api users with prmd, also add prmd docs for homebrews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "devise"
 gem "kaminari"
 gem "versionist"
 gem "jbuilder"
+gem "prmd"
 
 group :development do
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     json (1.8.1)
     json-schema (2.5.0)
       addressable (~> 2.3)
+    json_schema (0.4.0)
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -164,6 +165,9 @@ GEM
     normalize-rails (3.0.1)
     orm_adapter (0.5.0)
     pg (0.18.1)
+    prmd (0.7.0)
+      erubis (~> 2.7)
+      json_schema (~> 0.3, >= 0.3.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -318,6 +322,7 @@ DEPENDENCIES
   newrelic_rpm
   normalize-rails (~> 3.0.0)
   pg
+  prmd
   pry-rails
   rack-timeout
   rails (= 4.2.0)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,5 @@
+class API::V1::UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,8 @@
 class API::V1::UsersController < ApplicationController
+  def index
+    @user = User.all
+  end
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/views/api/v1/users/index.jbuilder
+++ b/app/views/api/v1/users/index.jbuilder
@@ -1,0 +1,9 @@
+json.users @users do |user|
+  json.extract! @user,
+    :id,
+    :created_at,
+    :updated_at,
+    :email,
+    :first_name,
+    :last_name
+end

--- a/app/views/api/v1/users/show.jbuilder
+++ b/app/views/api/v1/users/show.jbuilder
@@ -1,0 +1,7 @@
+json.extract! @user,
+  :id,
+  :created_at,
+  :updated_at,
+  :email,
+  :first_name,
+  :last_name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       default: true
     ) do
       resources :homebrews, only: [:index, :show]
+      resources :users, only: :show
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       default: true
     ) do
       resources :homebrews, only: [:index, :show]
-      resources :users, only: :show
+      resources :users, only: [:index, :show]
     end
   end
 end

--- a/docs/schemata/homebrew.json
+++ b/docs/schemata/homebrew.json
@@ -61,27 +61,6 @@
   "description": "Hombrewed beers that users submit for their friends to review",
   "links": [
     {
-      "description": "Create a new homebrew.",
-      "href": "/homebrews",
-      "method": "POST",
-      "rel": "create",
-      "schema": {
-        "properties": {
-        },
-        "type": [
-          "object"
-        ]
-      },
-      "title": "Create"
-    },
-    {
-      "description": "Delete an existing homebrew.",
-      "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
-      "method": "DELETE",
-      "rel": "destroy",
-      "title": "Delete"
-    },
-    {
       "description": "Info for existing homebrew.",
       "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
       "method": "GET",
@@ -94,20 +73,6 @@
       "method": "GET",
       "rel": "instances",
       "title": "List"
-    },
-    {
-      "description": "Update an existing homebrew.",
-      "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
-      "method": "PATCH",
-      "rel": "update",
-      "schema": {
-        "properties": {
-        },
-        "type": [
-          "object"
-        ]
-      },
-      "title": "Update"
     }
   ],
   "properties": {

--- a/docs/schemata/homebrew.json
+++ b/docs/schemata/homebrew.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "title": "Homebrew Reviews - Homebrews",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of homebrew",
+      "example": 10,
+      "type": [
+        "number"
+      ]
+    },
+    "identity": {
+      "$ref": "/schemata/homebrew#/definitions/id"
+    },
+    "created_at": {
+      "description": "when homebrew was created",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "updated_at": {
+      "description": "when homebrew was updated",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "brewer_id": {
+      "description": "id of the user who added the homebrew",
+      "example": 5,
+      "type": [
+        "number"
+      ]
+    },
+    "name": {
+      "description": "name the user gave the homebrew",
+      "example": "Extra-hoppy IPA",
+      "type": [
+        "string"
+      ]
+    },
+    "date_brewed": {
+      "description": "name the user gave the homebrew",
+      "example": "2015-01-12T20:20:47-05:00",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "description": {
+      "description": "an optional description of the homebrew",
+      "example": "A hoppier version of my regular IPA.",
+      "type": [
+        "string"
+      ]
+    }
+  },
+  "description": "Hombrewed beers that users submit for their friends to review",
+  "links": [
+    {
+      "description": "Create a new homebrew.",
+      "href": "/homebrews",
+      "method": "POST",
+      "rel": "create",
+      "schema": {
+        "properties": {
+        },
+        "type": [
+          "object"
+        ]
+      },
+      "title": "Create"
+    },
+    {
+      "description": "Delete an existing homebrew.",
+      "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
+      "method": "DELETE",
+      "rel": "destroy",
+      "title": "Delete"
+    },
+    {
+      "description": "Info for existing homebrew.",
+      "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info"
+    },
+    {
+      "description": "List existing homebrews.",
+      "href": "/homebrews",
+      "method": "GET",
+      "rel": "instances",
+      "title": "List"
+    },
+    {
+      "description": "Update an existing homebrew.",
+      "href": "/homebrews/{(%2Fschemata%2Fhomebrew%23%2Fdefinitions%2Fidentity)}",
+      "method": "PATCH",
+      "rel": "update",
+      "schema": {
+        "properties": {
+        },
+        "type": [
+          "object"
+        ]
+      },
+      "title": "Update"
+    }
+  ],
+  "properties": {
+    "created_at": {
+      "$ref": "/schemata/homebrew#/definitions/created_at"
+    },
+    "id": {
+      "$ref": "/schemata/homebrew#/definitions/id"
+    },
+    "updated_at": {
+      "$ref": "/schemata/homebrew#/definitions/updated_at"
+    },
+    "brewer_id": {
+      "$ref": "/schemata/homebrew#/definitions/brewer_id"
+    },
+    "name": {
+      "$ref": "/schemata/homebrew#/definitions/name"
+    },
+    "date_brewed": {
+      "$ref": "/schemata/homebrew#/definitions/date_brewed"
+    },
+    "description": {
+      "$ref": "/schemata/homebrew#/definitions/description"
+    }
+  },
+  "required": [
+    "id",
+    "brewer_id",
+    "name",
+    "date_brewed",
+    "created_at",
+    "updated_at"
+  ],
+  "type": [
+    "object"
+  ],
+  "id": "schemata/homebrew"
+}

--- a/docs/schemata/user.json
+++ b/docs/schemata/user.json
@@ -54,27 +54,6 @@
   "description": "The app's users",
   "links": [
     {
-      "description": "Create a new user.",
-      "href": "/users",
-      "method": "POST",
-      "rel": "create",
-      "schema": {
-        "properties": {
-        },
-        "type": [
-          "object"
-        ]
-      },
-      "title": "Create"
-    },
-    {
-      "description": "Delete an existing user.",
-      "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
-      "method": "DELETE",
-      "rel": "destroy",
-      "title": "Delete"
-    },
-    {
       "description": "Info for existing user.",
       "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
       "method": "GET",
@@ -87,20 +66,6 @@
       "method": "GET",
       "rel": "instances",
       "title": "List"
-    },
-    {
-      "description": "Update an existing user.",
-      "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
-      "method": "PATCH",
-      "rel": "update",
-      "schema": {
-        "properties": {
-        },
-        "type": [
-          "object"
-        ]
-      },
-      "title": "Update"
     }
   ],
   "properties": {

--- a/docs/schemata/user.json
+++ b/docs/schemata/user.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "title": "Homebrew Reviews - Users",
+  "definitions": {
+    "id": {
+      "description": "unique identifier of user",
+      "example": 5,
+      "type": [
+        "number"
+      ]
+    },
+    "identity": {
+      "$ref": "/schemata/user#/definitions/id"
+    },
+    "created_at": {
+      "description": "when user was created",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "updated_at": {
+      "description": "when user was updated",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "email": {
+      "description": "email address of user",
+      "example": "bobloblaw@bobloblawslawblog.com",
+      "format": "email",
+      "type": [
+        "string"
+      ]
+    },
+    "first_name": {
+      "description": "first name of user",
+      "example": "Bob",
+      "type": [
+        "string"
+      ]
+    },
+    "last_name": {
+      "description": "last name of user",
+      "example": "Loblaw",
+      "type": [
+        "string"
+      ]
+    }
+  },
+  "description": "The app's users",
+  "links": [
+    {
+      "description": "Create a new user.",
+      "href": "/users",
+      "method": "POST",
+      "rel": "create",
+      "schema": {
+        "properties": {
+        },
+        "type": [
+          "object"
+        ]
+      },
+      "title": "Create"
+    },
+    {
+      "description": "Delete an existing user.",
+      "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
+      "method": "DELETE",
+      "rel": "destroy",
+      "title": "Delete"
+    },
+    {
+      "description": "Info for existing user.",
+      "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
+      "method": "GET",
+      "rel": "self",
+      "title": "Info"
+    },
+    {
+      "description": "List existing users.",
+      "href": "/users",
+      "method": "GET",
+      "rel": "instances",
+      "title": "List"
+    },
+    {
+      "description": "Update an existing user.",
+      "href": "/users/{(%2Fschemata%2Fuser%23%2Fdefinitions%2Fidentity)}",
+      "method": "PATCH",
+      "rel": "update",
+      "schema": {
+        "properties": {
+        },
+        "type": [
+          "object"
+        ]
+      },
+      "title": "Update"
+    }
+  ],
+  "properties": {
+    "created_at": {
+      "$ref": "/schemata/user#/definitions/created_at"
+    },
+    "id": {
+      "$ref": "/schemata/user#/definitions/id"
+    },
+    "updated_at": {
+      "$ref": "/schemata/user#/definitions/updated_at"
+    },
+    "email": {
+      "$ref": "/schemata/user#/definitions/email"
+    },
+    "first_name": {
+      "$ref": "/schemata/user#/definitions/first_name"
+    },
+    "last_name": {
+      "$ref": "/schemata/user#/definitions/last_name"
+    }
+  },
+  "type": [
+    "object"
+  ],
+  "id": "schemata/user"
+}

--- a/docs/schemata/user.json
+++ b/docs/schemata/user.json
@@ -88,6 +88,14 @@
       "$ref": "/schemata/user#/definitions/last_name"
     }
   },
+  "required": [
+    "id",
+    "created_at",
+    "updated_at",
+    "email",
+    "first_name",
+    "last_name"
+  ],
   "type": [
     "object"
   ],

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "Homebrew Reviews API",
+  "id": "homebrew-reviews",
+  "links": [{
+   "href": "http://localhost:3000/api/",
+   "rel": "self"
+  }],
+  "title": "Homebrew Reviews API"
+}

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "definitions": {
+    "user": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Homebrew Reviews - Users",
+      "definitions": {
+        "id": {
+          "description": "unique identifier of user",
+          "example": 5,
+          "type": [
+            "number"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/user/definitions/id"
+        },
+        "created_at": {
+          "description": "when user was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when user was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "description": "email address of user",
+          "example": "bobloblaw@bobloblawslawblog.com",
+          "format": "email",
+          "type": [
+            "string"
+          ]
+        },
+        "first_name": {
+          "description": "first name of user",
+          "example": "Bob",
+          "type": [
+            "string"
+          ]
+        },
+        "last_name": {
+          "description": "last name of user",
+          "example": "Loblaw",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "description": "The app's users",
+      "links": [
+        {
+          "description": "Info for existing user.",
+          "href": "/users/{(%23%2Fdefinitions%2Fuser%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List existing users.",
+          "href": "/users",
+          "method": "GET",
+          "rel": "instances",
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/user/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/user/definitions/id"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/user/definitions/updated_at"
+        },
+        "email": {
+          "$ref": "#/definitions/user/definitions/email"
+        },
+        "first_name": {
+          "$ref": "#/definitions/user/definitions/first_name"
+        },
+        "last_name": {
+          "$ref": "#/definitions/user/definitions/last_name"
+        }
+      },
+      "type": [
+        "object"
+      ]
+    }
+  },
+  "properties": {
+    "user": {
+      "$ref": "#/definitions/user"
+    }
+  },
+  "type": [
+    "object"
+  ],
+  "description": "Homebrew Reviews API",
+  "id": "homebrew-reviews",
+  "links": [
+    {
+      "href": "http://localhost:3000/api/",
+      "rel": "self"
+    }
+  ],
+  "title": "Homebrew Reviews API"
+}

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,118 @@
 {
   "$schema": "http://json-schema.org/draft-04/hyper-schema",
   "definitions": {
+    "homebrew": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Homebrew Reviews - Homebrews",
+      "definitions": {
+        "id": {
+          "description": "unique identifier of homebrew",
+          "example": 10,
+          "type": [
+            "number"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/homebrew/definitions/id"
+        },
+        "created_at": {
+          "description": "when homebrew was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when homebrew was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "brewer_id": {
+          "description": "id of the user who added the homebrew",
+          "example": 5,
+          "type": [
+            "number"
+          ]
+        },
+        "name": {
+          "description": "name the user gave the homebrew",
+          "example": "Extra-hoppy IPA",
+          "type": [
+            "string"
+          ]
+        },
+        "date_brewed": {
+          "description": "name the user gave the homebrew",
+          "example": "2015-01-12T20:20:47-05:00",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "an optional description of the homebrew",
+          "example": "A hoppier version of my regular IPA.",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "description": "Hombrewed beers that users submit for their friends to review",
+      "links": [
+        {
+          "description": "Info for existing homebrew.",
+          "href": "/homebrews/{(%23%2Fdefinitions%2Fhomebrew%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List existing homebrews.",
+          "href": "/homebrews",
+          "method": "GET",
+          "rel": "instances",
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/homebrew/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/homebrew/definitions/id"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/homebrew/definitions/updated_at"
+        },
+        "brewer_id": {
+          "$ref": "#/definitions/homebrew/definitions/brewer_id"
+        },
+        "name": {
+          "$ref": "#/definitions/homebrew/definitions/name"
+        },
+        "date_brewed": {
+          "$ref": "#/definitions/homebrew/definitions/date_brewed"
+        },
+        "description": {
+          "$ref": "#/definitions/homebrew/definitions/description"
+        }
+      },
+      "required": [
+        "id",
+        "brewer_id",
+        "name",
+        "date_brewed",
+        "created_at",
+        "updated_at"
+      ],
+      "type": [
+        "object"
+      ]
+    },
     "user": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "Homebrew Reviews - Users",
@@ -91,12 +203,23 @@
           "$ref": "#/definitions/user/definitions/last_name"
         }
       },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at",
+        "email",
+        "first_name",
+        "last_name"
+      ],
       "type": [
         "object"
       ]
     }
   },
   "properties": {
+    "homebrew": {
+      "$ref": "#/definitions/homebrew"
+    },
     "user": {
       "$ref": "#/definitions/user"
     }

--- a/schema.md
+++ b/schema.md
@@ -1,0 +1,75 @@
+## Users
+The app's users
+
+### Attributes
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **created_at** | *date-time* | when user was created | `"2012-01-01T12:00:00Z"` |
+| **id** | *number* | unique identifier of user | `5` |
+| **updated_at** | *date-time* | when user was updated | `"2012-01-01T12:00:00Z"` |
+| **email** | *email* | email address of user | `"bobloblaw@bobloblawslawblog.com"` |
+| **first_name** | *string* | first name of user | `"Bob"` |
+| **last_name** | *string* | last name of user | `"Loblaw"` |
+### Users Info
+Info for existing user.
+
+```
+GET /users/{user_id}
+```
+
+
+#### Curl Example
+```bash
+$ curl -n -X GET http://localhost:3000/api//users/$USER_ID
+
+```
+
+
+#### Response Example
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "created_at": "2012-01-01T12:00:00Z",
+  "id": 5,
+  "updated_at": "2012-01-01T12:00:00Z",
+  "email": "bobloblaw@bobloblawslawblog.com",
+  "first_name": "Bob",
+  "last_name": "Loblaw"
+}
+```
+
+### Users List
+List existing users.
+
+```
+GET /users
+```
+
+
+#### Curl Example
+```bash
+$ curl -n -X GET http://localhost:3000/api//users
+
+```
+
+
+#### Response Example
+```
+HTTP/1.1 200 OK
+```
+```json
+[
+  {
+    "created_at": "2012-01-01T12:00:00Z",
+    "id": 5,
+    "updated_at": "2012-01-01T12:00:00Z",
+    "email": "bobloblaw@bobloblawslawblog.com",
+    "first_name": "Bob",
+    "last_name": "Loblaw"
+  }
+]
+```
+
+

--- a/schema.md
+++ b/schema.md
@@ -1,3 +1,81 @@
+## Homebrews
+Hombrewed beers that users submit for their friends to review
+
+### Attributes
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **created_at** | *date-time* | when homebrew was created | `"2012-01-01T12:00:00Z"` |
+| **id** | *number* | unique identifier of homebrew | `10` |
+| **updated_at** | *date-time* | when homebrew was updated | `"2012-01-01T12:00:00Z"` |
+| **brewer_id** | *number* | id of the user who added the homebrew | `5` |
+| **name** | *string* | name the user gave the homebrew | `"Extra-hoppy IPA"` |
+| **date_brewed** | *date-time* | name the user gave the homebrew | `"2015-01-12T20:20:47-05:00"` |
+| **description** | *string* | an optional description of the homebrew | `"A hoppier version of my regular IPA."` |
+### Homebrews Info
+Info for existing homebrew.
+
+```
+GET /homebrews/{homebrew_id}
+```
+
+
+#### Curl Example
+```bash
+$ curl -n -X GET http://localhost:3000/api//homebrews/$HOMEBREW_ID
+
+```
+
+
+#### Response Example
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "created_at": "2012-01-01T12:00:00Z",
+  "id": 10,
+  "updated_at": "2012-01-01T12:00:00Z",
+  "brewer_id": 5,
+  "name": "Extra-hoppy IPA",
+  "date_brewed": "2015-01-12T20:20:47-05:00",
+  "description": "A hoppier version of my regular IPA."
+}
+```
+
+### Homebrews List
+List existing homebrews.
+
+```
+GET /homebrews
+```
+
+
+#### Curl Example
+```bash
+$ curl -n -X GET http://localhost:3000/api//homebrews
+
+```
+
+
+#### Response Example
+```
+HTTP/1.1 200 OK
+```
+```json
+[
+  {
+    "created_at": "2012-01-01T12:00:00Z",
+    "id": 10,
+    "updated_at": "2012-01-01T12:00:00Z",
+    "brewer_id": 5,
+    "name": "Extra-hoppy IPA",
+    "date_brewed": "2015-01-12T20:20:47-05:00",
+    "description": "A hoppier version of my regular IPA."
+  }
+]
+```
+
+
 ## Users
 The app's users
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe API::V1::UsersController do
+  describe "Fetching all users" do
+    it "returns all the users, ordered by last name, then first name" do
+      last_user = FactoryGirl.create(:user, last_name: "Smith", first_name: "Zelda")
+      first_user = FactoryGirl.create(:user)
+      middle_user = FactoryGirl.create(:user, last_name: "Smith", first_name: "Alice")
+
+      get :index, {}, { "Accept" => "application/vnd.mycompany.com; version=1" }
+
+      expect(response.status).to eq 200
+      expect(response).to match_response_schema("users")
+    end
+  end
+
+  describe "Fetching a user" do
+    it "returns a single user" do
+      user = FactoryGirl.create(:user)
+
+      get :show, { id: user.id }, {  "Accept" => "application/vnd.mycompany.com; version=1" }
+
+      expect(response.status).to eq 200
+      expect(response).to match_response_schema("user")
+    end
+  end
+end

--- a/spec/support/api/schemas/user.json
+++ b/spec/support/api/schemas/user.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "unique identifier of user",
+      "example": 5,
+      "type": [
+        "number"
+      ]
+    },
+    "created_at": {
+      "description": "when user was created",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "updated_at": {
+      "description": "when user was updated",
+      "example": "2012-01-01T12:00:00Z",
+      "format": "date-time",
+      "type": [
+        "string"
+      ]
+    },
+    "email": {
+      "description": "email address of user",
+      "example": "bobloblaw@bobloblawslawblog.com",
+      "format": "email",
+      "type": [
+        "string"
+      ]
+    },
+    "first_name": {
+      "description": "first name of user",
+      "example": "Bob",
+      "type": [
+        "string"
+      ]
+    },
+    "last_name": {
+      "description": "last name of user",
+      "example": "Loblaw",
+      "type": [
+        "string"
+      ]
+    }
+  },
+  "required": ["id", "created_at", "updated_at", "email", "first_name", "last_name"]
+}

--- a/spec/support/api/schemas/users.json
+++ b/spec/support/api/schemas/users.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Users set",
+  "type": "object",
+  "properties": {
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "title": "User",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "unique identifier of user",
+              "example": 5,
+              "type": [
+                "number"
+              ]
+            },
+            "created_at": {
+              "description": "when user was created",
+              "example": "2012-01-01T12:00:00Z",
+              "format": "date-time",
+              "type": [
+                "string"
+              ]
+            },
+            "updated_at": {
+              "description": "when user was updated",
+              "example": "2012-01-01T12:00:00Z",
+              "format": "date-time",
+              "type": [
+                "string"
+              ]
+            },
+            "email": {
+              "description": "email address of user",
+              "example": "bobloblaw@bobloblawslawblog.com",
+              "format": "email",
+              "type": [
+                "string"
+              ]
+            },
+            "first_name": {
+              "description": "first name of user",
+              "example": "Bob",
+              "type": [
+                "string"
+              ]
+            },
+            "last_name": {
+              "description": "last name of user",
+              "example": "Loblaw",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "required": ["id", "created_at", "updated_at", "email", "first_name", "last_name"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Using prmd gem to generate documentation for the API for users index and show.

There's a whole lot of duplication, both in the tests and in my jbuilder templates.
- Can I make my tests rely on the docs generated by prmd (in `docs/schemata/`) instead of having to create separate `.json` files for each request in `spec/support/api/schemas`?  I'm basically just copy-pasting stuff from the prmd docs into those test files.
- Can I reference, for ex., the `users/show.jbuilder` template inside by `users/index.jbuilder` template?  (Yes I can, just need to do it)
