### PR TITLE
Api create & update homebrews

### DIFF
--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -20,7 +20,7 @@ class API::V1::HomebrewsController < ApplicationController
   protected
 
   def homebrew_params
-    params.require(:homebrew).permit(:name, :date_brewed, :description)
+    params.require(:homebrew).permit(:name, :date_brewed, :description, tag_ids: [])
   end
 
   def ensure_valid_api_key!

--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -22,7 +22,13 @@ class API::V1::HomebrewsController < ApplicationController
   def update
     @homebrew = Homebrew.find(params[:id])
 
-    authorize_to_edit(@homebrew)
+    return render_unauthorized if !authenticated_user.brewed?(@homebrew)
+
+    if @homebrew.update(homebrew_params)
+      render :show, status: 200
+    else
+      render json: { errors: @homebrew.errors }, status: 422
+    end
   end
 
   protected
@@ -37,10 +43,6 @@ class API::V1::HomebrewsController < ApplicationController
 
   def api_key
     @api_key ||= APIKey.from_request(request)
-  end
-
-  def authorize_to_edit(homebrew)
-    authenticated_user.brewed?(homebrew) || render_unauthorized
   end
 
   def authenticated_user

--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -1,5 +1,5 @@
 class API::V1::HomebrewsController < ApplicationController
-  before_action :ensure_valid_api_key!, only: :create
+  before_action :ensure_valid_api_key!, only: [:create, :update]
 
   def index
     @homebrews = Homebrew.all
@@ -19,6 +19,12 @@ class API::V1::HomebrewsController < ApplicationController
     end
   end
 
+  def update
+    @homebrew = Homebrew.find(params[:id])
+
+    authorize_to_edit(@homebrew)
+  end
+
   protected
 
   def homebrew_params
@@ -31,6 +37,10 @@ class API::V1::HomebrewsController < ApplicationController
 
   def api_key
     @api_key ||= APIKey.from_request(request)
+  end
+
+  def authorize_to_edit(homebrew)
+    authenticated_user.brewed?(homebrew) || render_unauthorized
   end
 
   def authenticated_user

--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -1,9 +1,29 @@
 class API::V1::HomebrewsController < ApplicationController
+  before_action :ensure_valid_api_key!, only: :create
+
   def index
     @homebrews = Homebrew.all
   end
 
   def show
     @homebrew = Homebrew.find(params[:id])
+  end
+
+  def create
+  end
+
+  protected
+
+  def ensure_valid_api_key!
+    api_key || render_unauthorized
+  end
+
+  def api_key
+    @api_key ||= APIKey.from_request(request)
+  end
+
+  def render_unauthorized
+    self.headers["WWW-Authenticate"] = 'Token realm="Application"'
+    render json: "Bad credentials", status: 401
   end
 end

--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -10,9 +10,18 @@ class API::V1::HomebrewsController < ApplicationController
   end
 
   def create
+    @homebrew = authenticated_user.homebrews.build(homebrew_params)
+
+    if @homebrew.save
+      render :show, status: 201
+    end
   end
 
   protected
+
+  def homebrew_params
+    params.require(:homebrew).permit(:name, :date_brewed, :description)
+  end
 
   def ensure_valid_api_key!
     api_key || render_unauthorized
@@ -20,6 +29,10 @@ class API::V1::HomebrewsController < ApplicationController
 
   def api_key
     @api_key ||= APIKey.from_request(request)
+  end
+
+  def authenticated_user
+    api_key.user if api_key
   end
 
   def render_unauthorized

--- a/app/controllers/api/v1/homebrews_controller.rb
+++ b/app/controllers/api/v1/homebrews_controller.rb
@@ -14,6 +14,8 @@ class API::V1::HomebrewsController < ApplicationController
 
     if @homebrew.save
       render :show, status: 201
+    else
+      render json: { errors: @homebrew.errors }, status: 422
     end
   end
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,9 @@
+class APIKey < ActiveRecord::Base
+  belongs_to :user
+
+  validates :user, presence: true
+  validates :access_token,
+    presence: true,
+    uniqueness: true
+  validates :expires_at, presence: true
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -6,4 +6,11 @@ class APIKey < ActiveRecord::Base
     presence: true,
     uniqueness: true
   validates :expires_at, presence: true
+
+  def self.from_request(request)
+    return unless request.authorization
+
+    access_token = request.authorization.gsub(/\AToken token=/, '')
+    find_by(access_token: access_token)
+  end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,10 +7,29 @@ class APIKey < ActiveRecord::Base
     uniqueness: true
   validates :expires_at, presence: true
 
+  before_validation :set_access_token, :set_expires_at, on: :create
+
   def self.from_request(request)
     return unless request.authorization
 
     access_token = request.authorization.gsub(/\AToken token=/, '')
     find_by(access_token: access_token)
+  end
+
+  private
+
+  def set_access_token
+    return if access_token.present?
+
+    begin
+      self.access_token = SecureRandom.hex
+    end while self.class.exists?(access_token: self.access_token)
+  end
+
+
+  def set_expires_at
+    return if expires_at.present?
+
+    self.expires_at = Time.now + 30.days
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ActiveRecord::Base
   validates :first_name, presence: true
   validates :last_name, presence: true
 
+  after_create :create_api_key
+
   def full_name
     "#{first_name} #{last_name}"
   end
@@ -59,5 +61,11 @@ class User < ActiveRecord::Base
 
   def brewed?(homebrew)
     homebrew.brewer == self
+  end
+
+  private
+
+  def create_api_key
+    api_keys.create
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,10 @@ class User < ActiveRecord::Base
     homebrew.brewer == self
   end
 
+  def api_key
+    api_keys.where("expires_at > ?", Time.now).first || api_keys.create
+  end
+
   private
 
   def create_api_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ActiveRecord::Base
   has_many :inverse_friends,
     through: :inverse_friendships,
     source: :user
+  has_many :api_keys,
+    dependent: :destroy
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,7 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'localhost:7000' }
+  
+  # Don't raise error if unpermitted params are passed to controllers
+  config.action_controller.action_on_unpermitted_parameters = :log
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,7 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'www.example.com' }
+
+  # Don't raise error if unpermitted params are passed to controllers
+  config.action_controller.action_on_unpermitted_parameters = :log
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       :defaults => {:format => :json},
       default: true
     ) do
-      resources :homebrews, only: [:index, :show, :create]
+      resources :homebrews, only: [:index, :show, :create, :update]
       resources :users, only: [:index, :show]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       :defaults => {:format => :json},
       default: true
     ) do
-      resources :homebrews, only: [:index, :show]
+      resources :homebrews, only: [:index, :show, :create]
       resources :users, only: [:index, :show]
     end
   end

--- a/db/migrate/20150113151443_create_api_keys.rb
+++ b/db/migrate/20150113151443_create_api_keys.rb
@@ -1,0 +1,14 @@
+class CreateAPIKeys < ActiveRecord::Migration
+  def change
+    create_table :api_keys do |t|
+      t.integer :user_id, null: false
+      t.string :access_token, null: false
+      t.datetime :expires_at, null: false
+
+      t.timestamps null: false
+    end
+    
+    add_index :api_keys, :user_id
+    add_index :api_keys, :access_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150110201343) do
+ActiveRecord::Schema.define(version: 20150113151443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "api_keys", force: :cascade do |t|
+    t.integer  "user_id",      null: false
+    t.string   "access_token", null: false
+    t.datetime "expires_at",   null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "api_keys", ["access_token"], name: "index_api_keys_on_access_token", unique: true, using: :btree
+  add_index "api_keys", ["user_id"], name: "index_api_keys_on_user_id", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -58,7 +58,7 @@ describe API::V1::HomebrewsController do
           post :create, homebrew: { invalid: "" }
 
           expect(response.status).to eq 422
-          expect(response.body).to eq "Unprocessable entity"
+          expect(response.body).to include "can't be blank"
         end
       end
     end

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -64,7 +64,7 @@ describe API::V1::HomebrewsController do
       post :create, homebrew: { name: "Extra Hoppy IPA" }
 
       expect(response.status).to eq 401
-      expect(response.body).to eq "Bad credentials"
+      expect(response.body).to include "Bad credentials"
     end
   end
 end

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -70,4 +70,62 @@ describe API::V1::HomebrewsController do
       expect(response.body).to include "Bad credentials"
     end
   end
+
+  describe "Updating a homebrew" do
+    context "with access token" do
+      let(:api_key) { FactoryGirl.create(:api_key) }
+      let(:current_user) { api_key.user }
+
+      before do
+        mock_authentication_with(api_key)
+      end
+
+      context "with brewer's access token" do
+        let(:homebrew) { FactoryGirl.create(:homebrew, brewer: current_user) }
+
+        context "with valid attributes" do
+          it "updates the homebrew" do
+            expect {
+              put :update, id: homebrew.id, homebrew: { description: "Best beer ever." }
+            }.to_not change { Homebrew.count }
+
+            homebrew.reload
+
+            expect(response.status).to eq 200
+            expect(response).to match_response_schema("homebrew")
+            expect(homebrew.description).to eq "Best beer ever."
+          end
+        end
+
+        context "with invalid attributes" do
+          it "is not successful" do
+            put :update, id: homebrew.id, homebrew: { name: "" }
+
+            expect(response.status).to eq 422
+            expect(response.body).to include "can't be blank"
+          end
+        end
+      end
+
+      context "with different user's access token" do
+        it "is unauthorized" do
+          homebrew = FactoryGirl.create(:homebrew)
+
+          put :update, id: homebrew.id, homebrew: { description: "Best beer ever." }
+
+          expect(response.status).to eq 401
+          expect(response.body).to include "Bad credentials"
+        end
+      end
+    end
+
+    context "without valid access token" do
+      it "is unauthorized" do
+        put :update, id: 'anything'
+
+        expect(response.status).to eq 401
+        expect(response.body).to include "Bad credentials"
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -39,12 +39,15 @@ describe API::V1::HomebrewsController do
 
       context "with valid attributes" do
         it "creates a new homebrew" do
+          tags = FactoryGirl.create_list(:tag, 2)
           homebrew_attributes = FactoryGirl.attributes_for(:homebrew)
+          homebrew_attributes.merge!(tag_ids: [tags.first.id, tags.last.id])
           expect(Homebrew.count).to eq 0
 
           post :create, homebrew: homebrew_attributes
 
           expect(Homebrew.count).to eq 1
+          expect(Homebrew.first.tags.count).to eq 2
           expect(response.status).to eq 201
           expect(response).to match_response_schema("homebrew")
         end

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -81,7 +81,7 @@ describe API::V1::HomebrewsController do
       end
 
       context "with brewer's access token" do
-        let(:homebrew) { FactoryGirl.create(:homebrew, brewer: current_user) }
+        let!(:homebrew) { FactoryGirl.create(:homebrew, brewer: current_user) }
 
         context "with valid attributes" do
           it "updates the homebrew" do

--- a/spec/controllers/api/v1/homebrews_controller_spec.rb
+++ b/spec/controllers/api/v1/homebrews_controller_spec.rb
@@ -27,4 +27,44 @@ describe API::V1::HomebrewsController do
       expect(response).to match_response_schema("homebrew")
     end
   end
+
+  describe "Creating a homebrew" do
+    context "with valid access token" do
+      let(:api_key) { FactoryGirl.create(:api_key) }
+      let(:current_user) { api_key.user }
+
+      before do
+        mock_authentication_with(api_key)
+      end
+
+      context "with valid attributes" do
+        it "creates a new homebrew" do
+          homebrew_attributes = FactoryGirl.attributes_for(:homebrew)
+          expect(Homebrew.count).to eq 0
+
+          post :create, homebrew: homebrew_attributes
+
+          expect(Homebrew.count).to eq 1
+          expect(response.status).to eq 201
+          expect(response).to match_response_schema("homebrew")
+        end
+      end
+
+      context "with invalid attributes" do
+        it "is not successful" do
+          post :create, homebrew: { invalid: "" }
+
+          expect(response.status).to eq 422
+          expect(response.body).to eq "Unprocessable entity"
+        end
+      end
+    end
+
+    it "requires a valid access token" do
+      post :create, homebrew: { name: "Extra Hoppy IPA" }
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq "Bad credentials"
+    end
+  end
 end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
   factory :api_key do
     user
-    sequence(:access_token) { |n| "#{n}c6f329e93bf8bb93871966b763d189c"}
-    expires_at { Time.zone.now + 1.week }
   end
 end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :api_key do
+    user
+    sequence(:access_token) { |n| "#{n}c6f329e93bf8bb93871966b763d189c"}
+    expires_at { Time.zone.now + 1.week }
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -14,4 +14,18 @@ RSpec.describe APIKey, :type => :model do
 
     it { should validate_uniqueness_of :access_token }
   end
+
+  describe ".from_request" do
+    it "finds access token from request authorization" do
+      api_key = FactoryGirl.create(:api_key)
+      request = double(authorization: "Token token=#{api_key.access_token}")
+
+      expect(APIKey.from_request(request)).to eq api_key
+    end
+
+    it "fails gracefully when request has no authorization" do
+      request = double(authorization: nil)
+      expect { APIKey.from_request(request) }.to_not raise_error
+    end
+  end
 end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe APIKey, :type => :model do
+  describe "associations" do
+    it { should belong_to :user }
+  end
+
+  describe "validations" do
+    subject { FactoryGirl.build(:api_key, expires_at: Time.now) }
+
+    it { should validate_presence_of :user }
+    it { should validate_presence_of :access_token }
+    it { should validate_presence_of :expires_at }
+
+    it { should validate_uniqueness_of :access_token }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe User, :type => :model do
     end
   end
 
+  describe "#api_key" do
+    it "returns active API key for user" do
+      user = FactoryGirl.build_stubbed(:user)
+      api_key = FactoryGirl.create(:api_key, user: user)
+
+      expect(user.api_key).to eq api_key
+    end
+
+    it "generates a new API key if user has no active API keys" do
+      user = FactoryGirl.build_stubbed(:user)
+      inactive_api_key = FactoryGirl.create(:api_key,
+        user: user, expires_at: 1.day.ago)
+
+      expect(user.api_key).to_not eq inactive_api_key
+      expect(user.api_key.class).to eq APIKey 
+    end
+  end
+
   describe "#all_friends" do
     let!(:user) { FactoryGirl.create(:user) }
     

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe User, :type => :model do
   it { should have_many(:inverse_friendships).dependent(:destroy) }
   it { should have_many(:friends).through(:friendships) }
   it { should have_many(:inverse_friends).through(:inverse_friendships) }
+  it { should have_many(:api_keys).dependent(:destroy) }
 
   it { should validate_presence_of :first_name }
   it { should validate_presence_of :last_name }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,23 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe User, :type => :model do
-  let!(:user) { FactoryGirl.create(:user) }
+  describe "associations" do
+    it { should have_many(:homebrews).dependent(:destroy) }
+    it { should have_many(:friendships).dependent(:destroy) }
+    it { should have_many(:inverse_friendships).dependent(:destroy) }
+    it { should have_many(:friends).through(:friendships) }
+    it { should have_many(:inverse_friends).through(:inverse_friendships) }
+    it { should have_many(:api_keys).dependent(:destroy) }
+  end
 
-  it { should have_many(:homebrews).dependent(:destroy) }
-  it { should have_many(:friendships).dependent(:destroy) }
-  it { should have_many(:inverse_friendships).dependent(:destroy) }
-  it { should have_many(:friends).through(:friendships) }
-  it { should have_many(:inverse_friends).through(:inverse_friendships) }
-  it { should have_many(:api_keys).dependent(:destroy) }
+  describe "validations" do
+    let!(:user) { FactoryGirl.create(:user) }
 
-  it { should validate_presence_of :first_name }
-  it { should validate_presence_of :last_name }
-  it { should validate_presence_of :email }
-  it { should validate_presence_of :password }
+    it { should validate_presence_of :first_name }
+    it { should validate_presence_of :last_name }
+    it { should validate_presence_of :email }
+    it { should validate_presence_of :password }
 
-  it { should validate_uniqueness_of :email}
+    it { should validate_uniqueness_of :email}
+  end
+
+
 
   describe "#all_friends" do
+    let!(:user) { FactoryGirl.create(:user) }
+    
     it "returns all a user's friends" do
       friendships = FactoryGirl.create_list(:friendship, 2, user: user)
       inverse_friendships = FactoryGirl.create_list(:friendship, 2, friend: user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe User, :type => :model do
     it { should validate_uniqueness_of :email}
   end
 
+  describe "after_create callback" do
+    it "generates an API key" do
+      user = FactoryGirl.create(:user)
 
+      expect(user.api_keys.count).to eq 1
+    end
+  end
 
   describe "#all_friends" do
     let!(:user) { FactoryGirl.create(:user) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
   config.render_views = true
+  config.include Helpers::Controllers, type: :controller
 end
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/helpers/controllers.rb
+++ b/spec/support/helpers/controllers.rb
@@ -1,0 +1,7 @@
+module Helpers
+  module Controllers
+    def mock_authentication_with(api_key)
+      request.env['HTTP_AUTHORIZATION'] = "Token token=#{api_key.access_token}"
+    end
+  end
+end


### PR DESCRIPTION
Added `create` & `update` actions for the API's homebrews controller that require token auth. Largely followed example in [Rescue Mission](https://github.com/LaunchAcademy/rescue_mission) app.

Should think about using Pundit for authorization in future.
